### PR TITLE
add dock widget hookimpl

### DIFF
--- a/napari_animation/__init__.py
+++ b/napari_animation/__init__.py
@@ -1,3 +1,3 @@
 from .animation import Animation
 from ._qt import AnimationWidget
-
+from ._hookimpls import napari_experimental_provide_dock_widgets

--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -19,7 +19,7 @@ class AnimationWidget(QWidget):
     frame : int
         Currently shown key frame.
     """
-    def __init__(self, viewer, parent=None):
+    def __init__(self, viewer: 'napari.viewer.Viewer', parent=None):
         super().__init__(parent=parent)
 
         

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-napari-plugin-engine>=0.1.6
+napari-plugin-engine>=0.1.9
 numpy


### PR DESCRIPTION
Add dock widget hookimpl, based on https://github.com/napari/napari/pull/2080. Will only work with versions of napari containing the `napari_experimental_provide_dock_widgets` hookspec