### PR TITLE
simplify the KeyFramesListWidget, everything now works on events

### DIFF
--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -29,25 +29,24 @@ class AnimationWidget(QWidget):
         # Create animation
         self.animation = Animation(viewer)
 
+        # Initialise UI
+        self._init_ui()
+
+        # establish key bindings and callbacks
+        self._add_keybind_callbacks()
+        self._add_callbacks()
+
+    def _init_ui(self):
+        """Initialise user interface"""
         self._layout = QVBoxLayout()
         self.setLayout(self._layout)
 
         self._layout.addWidget(QLabel('Animation Wizard', parent=self))
 
         self._init_keyframes_list_control_widget()
-
         self._init_keyframes_list_widget()
         self._init_frame_widget()
-
-        self.saveButton = QPushButton('Save Animation', parent=self)
-        self.saveButton.clicked.connect(self._save_callback)
-        self._layout.addWidget(self.saveButton)
-
-        # establish key bindings
-        self._add_keybind_callbacks()
-
-        # establish callbacks
-        self._add_callbacks()
+        self._init_save_button()
 
     def _add_keybind_callbacks(self):
         """Bind keys"""
@@ -66,6 +65,7 @@ class AnimationWidget(QWidget):
         )
         self.keyframesListControlWidget.captureButton.clicked.connect(
             self._capture_keyframe_callback)
+        self.saveButton.clicked.connect(self._save_callback)
 
     def _release_callbacks(self):
         """Release keys"""
@@ -93,6 +93,10 @@ class AnimationWidget(QWidget):
         self._layout.addWidget(self.keyframesListWidget)
         self.keyframesListWidget.setEnabled(False)
 
+    def _init_save_button(self):
+        self.saveButton = QPushButton('Save Animation', parent=self)
+        self._layout.addWidget(self.saveButton)
+
     def _get_interpolation_steps(self):
         return int(self.frameWidget.stepsSpinBox.value())
 
@@ -103,7 +107,6 @@ class AnimationWidget(QWidget):
         """Record current key-frame"""
         self.animation.capture_keyframe(steps=self._get_interpolation_steps(),
                                         ease=self._get_easing_function())
-        self.keyframesListWidget._add()
         if len(self.animation.key_frames) == 1:
             self.keyframesListControlWidget.deleteButton.setEnabled(True)
             self.keyframesListWidget.setEnabled(True)

--- a/napari_animation/_qt/keyframeslist_widget.py
+++ b/napari_animation/_qt/keyframeslist_widget.py
@@ -1,4 +1,3 @@
-from napari.utils.events import EventedList
 from qtpy.QtCore import QSize
 from qtpy.QtGui import QIcon, QImage, QPixmap
 from qtpy.QtWidgets import QListWidget, QListWidgetItem
@@ -22,9 +21,9 @@ class KeyFramesListWidget(QListWidget):
         super().__init__(parent=parent)
 
         self.animation = animation
-        self._frame_counter = 0
-        self._key_frame_id_to_label_map = {}
-        self._label_to_qlistwidgetitem_map = {}
+        self._frame_count = 0
+        self._item_id_to_key_frame = {}
+        self._key_frame_id_to_item = {}
 
         self._connect_key_frame_callbacks()
         self.setDragDropMode(super().InternalMove)
@@ -41,107 +40,71 @@ class KeyFramesListWidget(QListWidget):
     def _connect_key_frame_callbacks(self):
         """Connect events on the key frame list to their callbacks
         """
+        self.animation.key_frames.events.inserted.connect(self._add)
         self.animation.key_frames.events.removed.connect(self._remove)
-        self.animation.key_frames.events.moved.connect(self._update_frontend)
-        self.animation.key_frames.events.changed.connect(self._update_frontend)
-        self.animation.key_frames.events.reordered.connect(self._reorder)
+        self.animation.key_frames.events.reordered.connect(self._reorder_frontend)
 
     def dropEvent(self, event):
-        """update animation state on 'drop' of frame in key frames list
+        """update backend state on 'drop' of frame in key frames list
         """
         super().dropEvent(event)
-        self._update_backend()
+        self._reorder_backend()
 
     def _selection_callback(self, event):
         self._update_frame_number()
         self.animation.set_to_current_keyframe()
         self.parentWidget()._update_frame_widget_from_animation()
 
-    def _add(self):
+    def _add(self, event):
         """Generate QListWidgetItem for current keyframe, store its unique id and add it to self
         """
-        key_frame_idx = self.animation.frame
-        item = self._generate_list_item(key_frame_idx)
+        key_frame, idx = event.value, event.index
+        item = self._generate_list_item(key_frame)
+        self.insertItem(idx, item)
+        self._add_mappings(key_frame, item)
+        self._frame_count += 1
 
-        self.insertItem(key_frame_idx, item)
-
-        self._map_key_frame_to_id(key_frame_idx)
-        self._map_label_to_qlistwidgetitem(key_frame_idx)
-        self._frame_counter += 1
-
-    def insertItem(self, row, item):
-        """overrides QListWidget.insertItem to also update current index and frame number
-        """
-        super().insertItem(row, item)
-        self.setCurrentIndex(self.indexFromItem(item))
-        self._update_frame_number()
+    def _add_mappings(self, key_frame, item):
+        self._item_id_to_key_frame[id(item)] = key_frame
+        self._key_frame_id_to_item[id(key_frame)] = item
 
     def _remove(self, event):
         """Remove QListWidgetItem at event.index
         """
         self.takeItem(event.index)
-        self._remove_key_frame_id(event.value)
         self._update_frame_number()
 
-    def _remove_key_frame_id(self, key_frame):
-        """Remove key-frame id from self._key_frame_id_to_label_map
+    def _reorder_frontend(self, event=None):
+        """Reorder items in frontend based on current state in backend
         """
-        self._key_frame_id_to_label_map.pop(id(key_frame))
+        for idx, key_frame in enumerate(self.animation.key_frames):
+            item = self._key_frame_id_to_item[id(key_frame)]
+            self.takeItem(idx)
+            self.insertItem(item, idx)
 
-    def _reorder(self, event):
-        """Reorder QListWidgetItems
+    def _reorder_backend(self):
+        """reorder key frames in backend based on current state in frontend
         """
-        self.clear()
-        for idx, _ in enumerate(self.animation.key_frames):
-            self.addItem(self._generate_list_item(idx))
+        for idx, key_frame in enumerate(self.frontend_key_frames):
+            self.animation.key_frames[idx] = key_frame
 
-    def _update_backend(self):
-        """push current GUI state to self.animation
+    def insertItem(self, row, item):
+        """overrides QListWidget.insertItem to also update index to newly inserted item
         """
-        new_key_frames = [self._label_to_key_frame(label) for label in
-                          self.frontend_key_frame_labels]
-
-        # recreating the EventedList here and reconnecting events simplifies handling events
-        # which fire when we modify the list in place
-        self.animation.key_frames = EventedList(new_key_frames)
-        self._connect_key_frame_callbacks()
-        self._update_frame_number()
-
-    def _update_frontend(self, *args):
-        """update GUI state from self.animation state
-        """
-        # can't use self.addItems() and a list comprehension because self.addItems() only takes
-        # labels, not QListWidgetItem objects
-        self.clear()
-        for idx, _ in enumerate(self.animation.key_frames):
-            self.addItem(self._generate_list_item(idx))
+        super().insertItem(row, item)
+        self.setCurrentIndex(self.indexFromItem(item))
 
     def _update_frame_number(self):
         """update the frame number of self.animation based on selected item in frontend
         """
         self.animation.frame = self._get_selected_index()
 
-    def _generate_list_item(self, key_frame_idx):
-        """Generate a QListWidgetItem from a key frame at key_frame_idx
+    def _generate_list_item(self, key_frame):
+        """Generate a QListWidgetItem from a key-frame
         """
-        item = QListWidgetItem(self._generate_label(key_frame_idx))
-        key_frame = self._get_key_frame(key_frame_idx)
+        item = QListWidgetItem(f'key-frame {self._frame_count}')
         item.setIcon(self._icon_from_key_frame(key_frame))
         return item
-
-    def _map_key_frame_to_id(self, key_frame_idx):
-        """Store the unique id of the key frame at key_frame_idx in a dict of {id: key_frame_label}
-        """
-        key_frame_id = id(self._get_key_frame(key_frame_idx))
-        self._key_frame_id_to_label_map[key_frame_id] = self._generate_label(key_frame_idx)
-
-    def _map_label_to_qlistwidgetitem(self, key_frame_idx):
-        """Store the qlistwidgetitem associated with a particular label in a dict of
-        {label: qlistwidgetitem}
-        """
-        label = self._generate_label(key_frame_idx)
-        item = self.item(key_frame_idx)
-        self._label_to_qlistwidgetitem_map[label] = item
 
     def _icon_from_key_frame(self, key_frame):
         """Generate QIcon from a key frame
@@ -165,30 +128,6 @@ class KeyFramesListWidget(QListWidget):
             return -1
         else:
             return idxs[-1].row()
-
-    def _generate_label(self, key_frame_idx):
-        """Generate a label for a given key frame list index
-        """
-        key_frame = self._get_key_frame(key_frame_idx)
-        try:
-            label = self._key_frame_to_label(key_frame)
-        except KeyError:
-            label = f'key frame {self._frame_counter}'
-        return label
-
-    def _label_to_key_frame(self, label):
-        """gets the key frame associated with a given label in the frontend
-        """
-        return self.labels_to_key_frames[label]
-
-    def _label_to_qlistwidgetitem(self, label):
-        return self._label_to_qlistwidgetitem_map[label]
-
-    def _key_frame_to_label(self, key_frame):
-        """gets the label associated with a key frame
-        """
-        key_frame_id = id(key_frame)
-        return self._key_frame_id_to_label_map[key_frame_id]
 
     def _update_theme(self, theme):
         """
@@ -228,22 +167,10 @@ class KeyFramesListWidget(QListWidget):
             yield self.item(i)
 
     @property
-    def frontend_key_frame_labels(self):
-        """Labels for items currently in the keyframes list
-        """
+    def frontend_key_frames(self):
         for item in self.frontend_items:
-            yield item.text()
+            yield self._item_id_to_key_frame[id(item)]
 
-    @property
-    def backend_key_frame_labels(self):
-        """labels for key frames in the order present in the backend
-        """
-        return [self._key_frame_id_to_label_map[id(key_frame)] for key_frame in
-                self.animation.key_frames]
 
-    @property
-    def labels_to_key_frames(self):
-        """a dict of {label : key_frame}
-        """
-        return {label: key_frame for label, key_frame in zip(self.backend_key_frame_labels,
-                                                             self.animation.key_frames)}
+
+


### PR DESCRIPTION
this PR addresses #18 (only for the `KeyFramesListWidget`, not animation.frame) and simplifies the `KeyFramesListWidget` quite a bit.

Everything in the `KeyFramesListWidget` is now based on events and there's no more of that ugly recreation of the `EventedList` when updating things.

I didn't get around to fixing #16 with this but it's on the list!