### PR TITLE
improve margins on thumbnail

### DIFF
--- a/napari_animation/_qt/keyframeslist_widget.py
+++ b/napari_animation/_qt/keyframeslist_widget.py
@@ -30,13 +30,6 @@ class KeyFramesListWidget(QListWidget):
 
         self.itemClicked.connect(self._selection_callback)
 
-    def _init_styling(self):
-        self.setIconSize(QSize(64, 64))
-        stylesheet = '\n'.join(
-            [self._item_background_color, self._transparent_background]
-        )
-        self.setStyleSheet(stylesheet)
-
     def _connect_key_frame_callbacks(self):
         """Connect events on the key frame list to their callbacks
         """
@@ -148,10 +141,14 @@ class KeyFramesListWidget(QListWidget):
 
         transparent_background_qss = 'QListView{background: transparent;}'
 
+        item_qss = 'QListView::item{margin: 0px; padding: 0px; min-height: 32px; max-height: 32px;}' \
+                   'QImage{margin: 0px; padding: 0px; qproperty-alignment: AlignLeft;}' \
+
         style_sheet_components = [
             deselected_bg_color_qss,
             selected_bg_color_qss,
-            transparent_background_qss
+            transparent_background_qss,
+            item_qss
         ]
         style_sheet = '\n'.join(style_sheet_components)
 


### PR DESCRIPTION
This PR improves the margins and pads with background the thumbnails

Before:

<img width="1200" alt="Screen Shot 2021-02-02 at 6 52 37 PM" src="https://user-images.githubusercontent.com/6531703/106695787-2bd4e280-6590-11eb-8b12-aced53283b9d.png">

After:

<img width="1156" alt="Screen Shot 2021-02-02 at 7 51 10 PM" src="https://user-images.githubusercontent.com/6531703/106696356-69863b00-6591-11eb-95c2-35dee31e2456.png">

cc @alisterburt 