### PR TITLE
add imageio-ffmpeg as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 imageio
+imageio-ffmpeg
 napari>=0.4.4
 napari-plugin-engine>=0.1.9
 numpy


### PR DESCRIPTION
Adding imageio-ffmpeg as a requirement would reduce the need to install another thing for users who want it to *just work*. 
The tests in #34 currently fail beause of this - this would fix that. If we don't want to add this as a requirement, I can make sure separate 'test time' reqs are working as they do in napari